### PR TITLE
Allow different observation modes in Tiling_Observations script

### DIFF
--- a/src/tilepy/include/CampaignDefinition.py
+++ b/src/tilepy/include/CampaignDefinition.py
@@ -207,7 +207,7 @@ class ObservationParameters(object):
         ra=None,
         dec=None,
         sigma=None,
-        nside=None
+        nside=None,
     ):
         # Parsed args in command line
         self.skymap = skymap

--- a/src/tilepy/include/CampaignDefinition.py
+++ b/src/tilepy/include/CampaignDefinition.py
@@ -203,6 +203,11 @@ class ObservationParameters(object):
         outDir,
         pointingsFile,
         eventName=None,
+        mode="healpix",
+        ra=None,
+        dec=None,
+        sigma=None,
+        nside=None
     ):
         # Parsed args in command line
         self.skymap = skymap
@@ -212,6 +217,11 @@ class ObservationParameters(object):
         self.outDir = outDir
         self.pointingsFile = pointingsFile
         self.event_name = self.event_name if eventName is None else eventName
+        self.mode = mode
+        self.raSource = ra
+        self.decSource = dec
+        self.sigmaSource = sigma
+        self.nside = nside
 
     def from_configfile(self, filepath):
         ##################

--- a/src/tilepy/scripts/Tiling_Observations.py
+++ b/src/tilepy/scripts/Tiling_Observations.py
@@ -133,7 +133,7 @@ def main():
                 )
 
         if skymap is not None:
-            raise ValueError(f'Cannot specify a skymap URL when mode is "gaussian".')
+            raise ValueError('Cannot specify a skymap URL when mode is "gaussian".')
 
     ################################################
 


### PR DESCRIPTION
While the feature to create artificial guassian skymaps was introduced, it was not possible to use it outside of notebooks. Now it can be used via the `Tiling_Observations` command line script.