### PR TITLE
Get downloadMaxRetry as a standard string.

### DIFF
--- a/src/tilepy/include/CampaignDefinition.py
+++ b/src/tilepy/include/CampaignDefinition.py
@@ -292,9 +292,7 @@ class ObservationParameters(object):
         self.countPrevious = parser.getboolean(section, "countPrevious", fallback=None)
 
         section = "general"
-        self.downloadMaxRetry = int(
-            parser.get(section, "downloadMaxRetry", fallback=0)
-        )
+        self.downloadMaxRetry = int(parser.get(section, "downloadMaxRetry", fallback=0))
         self.downloadWaitPeriodRetry = float(
             parser.get(section, "downloadWaitPeriodRetry", fallback=0)
         )

--- a/src/tilepy/include/CampaignDefinition.py
+++ b/src/tilepy/include/CampaignDefinition.py
@@ -293,7 +293,7 @@ class ObservationParameters(object):
 
         section = "general"
         self.downloadMaxRetry = int(
-            parser.getboolean(section, "downloadMaxRetry", fallback=0)
+            parser.get(section, "downloadMaxRetry", fallback=0)
         )
         self.downloadWaitPeriodRetry = float(
             parser.get(section, "downloadWaitPeriodRetry", fallback=0)


### PR DESCRIPTION
If `downloadMaxRetry` is set to a number greater than 1, the following error will appear:

```bash
Traceback (most recent call last):
  File "/home/grbmgr/miniconda3/envs/tilepy/bin/Tiling_Observations", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/grbmgr/miniconda3/envs/tilepy/lib/python3.11/site-packages/tilepy/scripts/Tiling_Observations.py", line 155, in main
    obspar.from_configfile(cfgFile)
  File "/home/grbmgr/miniconda3/envs/tilepy/lib/python3.11/site-packages/tilepy/include/CampaignDefinition.py", line 296, in from_configfile
    parser.getboolean(section, "downloadMaxRetry", fallback=0)
  File "/home/grbmgr/miniconda3/envs/tilepy/lib/python3.11/configparser.py", line 844, in getboolean
    return self._get_conv(section, option, self._convert_to_boolean,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/grbmgr/miniconda3/envs/tilepy/lib/python3.11/configparser.py", line 824, in _get_conv
    return self._get(section, conv, option, raw=raw, vars=vars,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/grbmgr/miniconda3/envs/tilepy/lib/python3.11/configparser.py", line 819, in _get
    return conv(self.get(section, option, **kwargs))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/grbmgr/miniconda3/envs/tilepy/lib/python3.11/configparser.py", line 1184, in _convert_to_boolean
    raise ValueError('Not a boolean: %s' % value)
```

because it tries to cast the value to a boolean, while it should get it as a string and then convert it to an integer.

This PR fixes the issue.