### PR TITLE
fix: issue with missing pkg_resources

### DIFF
--- a/docs/auto_tutorials/index.rst
+++ b/docs/auto_tutorials/index.rst
@@ -6,6 +6,10 @@ Simulation Gallery
 Scripts and tutorials for tilepy simulations.
 
 
+.. raw:: html
+
+  <div id='sg-tag-list' class='sphx-glr-tag-list'></div>
+
 
 .. raw:: html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ tests = [
 docs = [
     "numpy<2",
     "python-ligo-lw",
-    "sphinx>=1.6",
+    "sphinx>=8,<9",
     "sphinx-astropy[confv2]",
     "sphinxcontrib-typer",
     "sphinxcontrib-bibtex",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,10 @@ tests = [
 ]
 
 docs = [
+    "setuptools<71",
     "numpy<2",
     "python-ligo-lw",
-    "sphinx>=8,<9",
+    "sphinx>=1.6",
     "sphinx-astropy[confv2]",
     "sphinxcontrib-typer",
     "sphinxcontrib-bibtex",


### PR DESCRIPTION
`pkg_resources` was removed in `setuptools>=71.` Pinning `setuptools<71` in the docs dependencies fixes the `sphinx-automodapi` build failure on  on Read the Docs.


Here : https://setuptools.pypa.io/en/stable/history.html#v82-0-0
For a discussion : https://discuss.python.org/t/pkg-resources-removal-how-to-go-from-there/106079

