### PR TITLE
Use setuptools<71 for all tilepy including docs, dev and so on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm[toml]>=8"]
+requires = ["setuptools>=64,<71", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -48,6 +48,7 @@ dependencies = [
           'mhealpy>=0.3.0,<0.4',
           'ligo.skymap>=2.0.0',
           "scikit-learn>=1.6.1",
+          "setuptools>=64,<71",
 ]
 
 [project.optional-dependencies]
@@ -60,7 +61,6 @@ tests = [
 ]
 
 docs = [
-    "setuptools<71",
     "numpy<2",
     "python-ligo-lw",
     "sphinx>=1.6",
@@ -73,6 +73,7 @@ docs = [
     "sphinx-gallery",
     "astropy-sphinx-theme",
     "sphinx-automodapi",
+    "setuptools>=64,<71",
 ]
 
 dev = [
@@ -177,4 +178,5 @@ package = true
 
 override-dependencies = [
     'healpy>=1.17.0',
+    "setuptools>=64,<71",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "healpy", specifier = ">=1.17.0" }]
+overrides = [
+    { name = "healpy", specifier = ">=1.17.0" },
+    { name = "setuptools", specifier = ">=64,<71" },
+]
 
 [[package]]
 name = "accessible-pygments"
@@ -7401,11 +7404,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "70.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/d8/10a70e86f6c28ae59f101a9de6d77bf70f147180fbf40c3af0f64080adc3/setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5", size = 2333112, upload-time = "2024-07-09T16:08:06.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/15/88e46eb9387e905704b69849618e699dc2f54407d8953cc4ec4b8b46528d/setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc", size = 931070, upload-time = "2024-07-09T16:07:58.829Z" },
 ]
 
 [[package]]
@@ -8366,6 +8369,7 @@ dependencies = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy" },
+    { name = "setuptools" },
     { name = "skyfield" },
     { name = "tables", version = "3.9.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "tables", version = "3.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
@@ -8412,6 +8416,7 @@ docs = [
     { name = "nbsphinx" },
     { name = "numpy" },
     { name = "python-ligo-lw" },
+    { name = "setuptools" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -8469,6 +8474,8 @@ requires-dist = [
     { name = "pytz" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "scipy", specifier = "<1.14.0" },
+    { name = "setuptools", specifier = ">=64,<71" },
+    { name = "setuptools", marker = "extra == 'docs'", specifier = ">=64,<71" },
     { name = "setuptools-scm", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "skyfield" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=1.6" },
@@ -8483,7 +8490,7 @@ requires-dist = [
     { name = "tilepy", extras = ["dev", "tests"], marker = "extra == 'all'" },
     { name = "tomli", marker = "extra == 'tests'" },
 ]
-provides-extras = ["tests", "docs", "dev", "all"]
+provides-extras = ["all", "dev", "docs", "tests"]
 
 [[package]]
 name = "tinycss2"


### PR DESCRIPTION
This should Fix all the issue with link to the "pkg_resources ModuleNotFoundError", in all the tilepy package. 