### PR TITLE
Fix issue with github.io/tilepy

### DIFF
--- a/index.html 
+++ b/index.html 
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://tilepy.readthedocs.io/en/latest">
+  </head>
+  <body>
+    <p>Redirecting to <a href="https://tilepy.readthedocs.io/en/latest">tilepy documentation</a>...</p>
+  </body>
+</html>


### PR DESCRIPTION
The link `https://astro-transients.github.io/tilepy/` is rendered via **GitHub Pages**, 
which is activated in the repository settings. However, GitHub Pages does not render 
Markdown properly when mixed with HTML tags, which causes the badges to appear as raw 
text instead of clickable links.

Since some people may have saved this link in their bookmarks, deactivating GitHub Pages 
would result in a **404 error** for them. Therefore, the best solution is to add an 
`index.html` file at the root of the repository that automatically redirects visitors 
to the ReadTheDocs documentation:

> https://tilepy.readthedocs.io/en/latest